### PR TITLE
Update 2.24

### DIFF
--- a/main.ly
+++ b/main.ly
@@ -1,3 +1,4 @@
+\version "2.18.2"
 \require "lilyjazz"
 
 \layout {

--- a/main.ly
+++ b/main.ly
@@ -1,5 +1,7 @@
-\version "2.18.2"
-\require "lilyjazz"
+\version "2.24.0"
+%#(set-global-staff-size 22)
+\include "jazzchords.ily"
+\include "lilyjazz.ily"
 
 \layout {
 
@@ -9,13 +11,10 @@
 
   ragged-right = ##f
 
-  \override Score.TextScript.font-name = #"LilyJAZZ Text"
-  \override Score.Clef #'break-visibility = #'#(#f #f #f)
-  \override Score.KeySignature #'break-visibility = #'#(#f #f #f)
-  \override Score.SystemStartBar #'collapse-height = #1
-
-  \jazzOn
-
+  \override Score.TextScript.font-name = #"lilyjazz-text"
+  \override Score.Clef.break-visibility = #'#(#f #f #f)
+  \override Score.KeySignature.break-visibility = #'#(#f #f #f)
+  \override Score.SystemStartBar.collapse-height = #1
 }
 
 \book {
@@ -24,12 +23,7 @@
 
     indent = 0\mm
     tagline = ##f
-    ragged-bottom = ##t
-
-    #(define fonts
-       (set-global-fonts
-        #:roman "LilyJAZZ Text"
-        #:factor (/ staff-height pt 20)))
+    ragged-bottom = ##f
 
     scoreTitleMarkup = \markup {
       \fill-line {

--- a/scores/aint_misbehavin.ly
+++ b/scores/aint_misbehavin.ly
@@ -1,4 +1,4 @@
-\version "2.18.2"
+\version "2.24.0"
 
 \score {
 

--- a/scores/aint_she_sweet.ly
+++ b/scores/aint_she_sweet.ly
@@ -1,4 +1,4 @@
-\version "2.18.2"
+\version "2.24.0"
 
 \score {
 

--- a/scores/all.ly
+++ b/scores/all.ly
@@ -1,4 +1,4 @@
-\version "2.18.2"
+\version "2.24.0"
 
 \pageBreak \include "aint_misbehavin.ly"
 \pageBreak \include "aint_she_sweet.ly"

--- a/scores/all.ly
+++ b/scores/all.ly
@@ -1,3 +1,5 @@
+\version "2.18.2"
+
 \pageBreak \include "aint_misbehavin.ly"
 \pageBreak \include "aint_she_sweet.ly"
 \pageBreak \include "dont_get_around_much_anymore.ly"

--- a/scores/dont_get_around_much_anymore.ly
+++ b/scores/dont_get_around_much_anymore.ly
@@ -1,4 +1,4 @@
-\version "2.18.2"
+\version "2.24.0"
 
 \score {
 
@@ -32,7 +32,7 @@
       % http://lilypond.org/doc/v2.18/Documentation/notation/beams
       \set Timing.beamExceptions = #'()
 
-      r8 e'4 d8 c g f e ~ | \bar ".|" e1 | r8 e'4 d8 c g f e ~ | e1 |
+      r8 e'4 d8 c g f e ~ | \bar ".|-|" e1 | r8 e'4 d8 c g f e ~ | e1 |
       \break
       r8 g4 f8 e d c4 | c'4. a8~ a2 | r8 e f fis g c, dis e | c1 | r8 e'4 d8 c g f e ~ |
       \bar "||"

--- a/scores/dont_get_around_much_anymore.ly
+++ b/scores/dont_get_around_much_anymore.ly
@@ -1,3 +1,5 @@
+\version "2.18.2"
+
 \score {
 
   \header {

--- a/scores/on_the_sunny_side_of_the_street.ly
+++ b/scores/on_the_sunny_side_of_the_street.ly
@@ -1,4 +1,4 @@
-\version "2.18.2"
+\version "2.24.0"
 
 \score {
 

--- a/scores/on_the_sunny_side_of_the_street.ly
+++ b/scores/on_the_sunny_side_of_the_street.ly
@@ -1,3 +1,5 @@
+\version "2.18.2"
+
 \score {
 
   \header {

--- a/scores/please_dont_talk_about_me_when_im_gone.ly
+++ b/scores/please_dont_talk_about_me_when_im_gone.ly
@@ -1,4 +1,4 @@
-\version "2.18.2"
+\version "2.24.0"
 
 \score {
 

--- a/scores/please_dont_talk_about_me_when_im_gone.ly
+++ b/scores/please_dont_talk_about_me_when_im_gone.ly
@@ -1,3 +1,5 @@
+\version "2.18.2"
+
 \score {
 
   \header {

--- a/scores/smile.ly
+++ b/scores/smile.ly
@@ -1,4 +1,4 @@
-\version "2.18.2"
+\version "2.24.0"
 
 \score {
 

--- a/scores/smile.ly
+++ b/scores/smile.ly
@@ -1,3 +1,5 @@
+\version "2.18.2"
+
 \score {
 
   \header {

--- a/scores/test.ly
+++ b/scores/test.ly
@@ -1,4 +1,4 @@
-\version "2.18.2"
+\version "2.24.0"
 
 \score {
   \header {

--- a/scores/test.ly
+++ b/scores/test.ly
@@ -1,3 +1,5 @@
+\version "2.18.2"
+
 \score {
   \header {
     title = "Tasty Testing"


### PR DESCRIPTION
Since I'm on a 64-bit mac, I wasn't able to see how these scores were supposed to look with 2.18.2, but I ran convert-ly on them against 2.24, and made an adjustment.

- The most up-to-date version of lilyjazz doesn't use \jazzOn. I deleted that and one other snippet that appeared to inhibit the font from showing up
- I wasn't able to figure out how to get that staff to show up behind the title, not like in the original blog post mentioned in the README. I wasn't sure how to dereference header.title when pulling in the new \score in the markup.
- I set ragged to false since I'm used to the real book filling up the page for single-page scores.
- I think the scores look kind of sparse, but when I tried setting the global-staff-size to a large value, the titles got too wide. I wonder if there's a way to dynamically scale them so they will always fit within the meter and the composer.

Note: to install the latest version of lilyjazz to a lilypond installation:

The following three files need to be copied to the "share" directory in ly:

- jazzchords.ily
- jazzextras.ily
- lilyjazz.ily

svg fonts need to be copied to svg directory

otf fonts need to be copied to otf directory

Any corrections to my PR greatly appreciated, as since I was unable to run 2.18.2, I'm sure I must have missed some sort of perspective you applied to the original repo.
